### PR TITLE
Add `use_cross` option

### DIFF
--- a/config/cargo-atcoder.toml
+++ b/config/cargo-atcoder.toml
@@ -1,5 +1,6 @@
 [atcoder]
 submit_via_binary = false # submit via binary by default
+use_cross = false         # use `cross` instead of `cargo` when generating binaries
 binary_column = 80        # maximum column number of generated binary (0 for no wrapping)
 update_interval = 1000    # interval time of fetching result (ms)
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ pub struct Config {
 #[derive(Clone, Debug, Deserialize)]
 pub struct AtCoder {
     pub submit_via_binary: bool,
+    pub use_cross: bool,
     pub binary_column: usize,
     pub update_interval: u64,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -513,7 +513,12 @@ fn gen_binary_source(
     let target = &config.profile.target;
     let binary_file = format!("target/{}/release/{}", target, problem_id);
 
-    let status = Command::new("cargo")
+    let program = if config.atcoder.use_cross {
+        "cross"
+    } else {
+        "cargo"
+    };
+    let status = Command::new(program)
         .arg("build")
         .arg(format!("--target={}", target))
         .arg("--release")


### PR DESCRIPTION
Like `use-cross` option of [actions-rs/cargo](https://github.com/actions-rs/cargo).

This option will be good for Windows/macOS users. (though I'm using only Linux)

![screenshot](https://user-images.githubusercontent.com/14125495/73139270-9f0b6500-40af-11ea-99f0-abfeee18cad1.png)