### PR TITLE
Add `strip_path` to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,23 @@ $ cargo atcoder result [FLAGS] <submission-id>
 ## 設定ファイル
 
 `~/.config/cargo-atcoder.toml` に設定ファイルが生成されます。適当にいじって下さい（そのうち説明を書く）。
+
+## macOS 環境の場合
+
+設定ファイルは `~/Library/Preferences/cargo-atcoder.toml` に生成されます。
+
+`x86_64-unknown-linux-musl` 向けのコンパイルを面倒無く実行するため、`[atcoder]` テーブル内で `use_cross = true` を指定するのがおすすめです。`use_cross` を有効化することで、[rust-embedded/cross](https://github.com/rust-embedded/cross) を使用したコンパイルを行うようになります。Docker が必要になるので注意してください。
+
+また、実行バイナリを軽量化するために使われる `strip` コマンドが、macOS に最初から入っているものだとうまくいかないため、**GNU版**の `strip` を導入するのもおすすめです。Homebrewであれば以下を実行すればインストールすることができます。
+
+```
+$ brew install binutils
+```
+
+標準では `/usr/local/opt/binutils/bin` の中にインストールされます。
+ここにPATHを通すか、あるいは `cargo-atcoder.toml` の `[atcoder]` テーブル内に以下のようにGNU版 `strip` の絶対パスを指定すればOKです。
+
+```
+[atcoder]
+strip_path = "/usr/local/opt/binutils/bin/strip"
+```

--- a/config/cargo-atcoder.toml
+++ b/config/cargo-atcoder.toml
@@ -3,6 +3,7 @@ submit_via_binary = false # submit via binary by default
 use_cross = false         # use `cross` instead of `cargo` when generating binaries
 binary_column = 80        # maximum column number of generated binary (0 for no wrapping)
 update_interval = 1000    # interval time of fetching result (ms)
+strip_path = "strip"      # specify `strip` command path. NOTE: if you use macOS, you have to install GNU strip and specify its path here.
 
 [profile]
 # target to use to generate binary

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,7 @@ pub struct AtCoder {
     pub use_cross: bool,
     pub binary_column: usize,
     pub update_interval: u64,
+    pub strip_path: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -624,7 +624,13 @@ fn gen_binary_source(
     let size = ByteSize::b(get_file_size(&binary_file)?);
     println!("Built binary size: {}", size);
 
-    let status = Command::new("strip").arg("-s").arg(&binary_file).status()?;
+    let status = Command::new(match config.atcoder.strip_path {
+        Some(ref p) => p,
+        None => "strip",
+    })
+    .arg("-s")
+    .arg(&binary_file)
+    .status()?;
     if !status.success() {
         return Err(anyhow!("strip failed"));
     }


### PR DESCRIPTION
I'm using macOS 10.15.1 (Catalina).
In my environment, when I ran `cargo atcoder submit a --bin`, the following error happened:

```
fatal error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip: no files specified
Error: strip failed
```

I guess this was because `strip` command in macOS is different from that in Linux.
So I installed `GNU strip` and specified its path instead of the original one. Then the error disappeared 💪

This PR will allow users to specify `strip` command path in config file and show macOS users how to submit to AtCoder by binary.

