### PR TITLE
Improve error message when cross is not found, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ $ cargo atcoder result [FLAGS] <submission-id>
 設定ファイルは `~/Library/Preferences/cargo-atcoder.toml` に生成されます。
 
 `x86_64-unknown-linux-musl` 向けのコンパイルを面倒無く実行するため、`[atcoder]` テーブル内で `use_cross = true` を指定するのがおすすめです。`use_cross` を有効化することで、[rust-embedded/cross](https://github.com/rust-embedded/cross) を使用したコンパイルを行うようになります。Docker が必要になるので注意してください。
+crossのインストールもお忘れなく。
+```
+$ cargo install cross
+```
 
 また、実行バイナリを軽量化するために使われる `strip` コマンドが、macOS に最初から入っているものだとうまくいかないため、**GNU版**の `strip` を導入するのもおすすめです。Homebrewであれば以下を実行すればインストールすることができます。
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -624,6 +624,11 @@ fn gen_binary_source(
     } else {
         "cargo"
     };
+
+    if which::which(program).is_err() {
+        return Err(anyhow!("Build failed. {} not found.", program))
+    }
+
     let status = Command::new(program)
         .arg("build")
         .arg(format!("--target={}", target))


### PR DESCRIPTION
When `use_cross = true` is set but cross is not found (installed), error message is as follows.

```
Error: No such file or directory (os error 2)
```

I know it's error message in std::process::Command but I think it may be unkind.
So I improve error message as follows with which::which function.

```
Error: Build failed. cross not found.
```

And add description to README in order not to forget to install `cross`.
I forgot :)

Thank you for great tool!
