### PR TITLE
Get unordinary input and output.

### DIFF
--- a/src/atcoder.rs
+++ b/src/atcoder.rs
@@ -456,6 +456,8 @@ impl AtCoder {
                     .next()
                     .unwrap()
                     .inner_html()
+                    .trim()
+                    .to_owned()
             };
             if label.starts_with("入力例") {
                 inputs_ja.push(f());

--- a/src/atcoder.rs
+++ b/src/atcoder.rs
@@ -439,6 +439,7 @@ impl AtCoder {
         for r in doc.select(&h3_sel) {
             let p = ElementRef::wrap(r.parent().unwrap()).unwrap();
             let label = p.select(&h3_sel).next().unwrap().inner_html();
+            let label = label.trim();
             // dbg!(r.parent().unwrap().first_child().unwrap().value());
 
             // let label = r

--- a/src/atcoder.rs
+++ b/src/atcoder.rs
@@ -436,7 +436,7 @@ impl AtCoder {
         let mut inputs_en = vec![];
         let mut outputs_en = vec![];
 
-        for r in doc.select(&Selector::parse("h3+pre").unwrap()) {
+        for r in doc.select(&h3_sel) {
             let p = ElementRef::wrap(r.parent().unwrap()).unwrap();
             let label = p.select(&h3_sel).next().unwrap().inner_html();
             // dbg!(r.parent().unwrap().first_child().unwrap().value());
@@ -450,18 +450,24 @@ impl AtCoder {
             //     .as_text()
             //     .unwrap();
 
+            let f = || {
+                p.select(&Selector::parse("pre").unwrap())
+                    .next()
+                    .unwrap()
+                    .inner_html()
+            };
             if label.starts_with("入力例") {
-                inputs_ja.push(r.inner_html().trim().to_owned());
+                inputs_ja.push(f());
             }
             if label.starts_with("出力例") {
-                outputs_ja.push(r.inner_html().trim().to_owned());
+                outputs_ja.push(f());
             }
 
             if label.starts_with("Sample Input") {
-                inputs_en.push(r.inner_html().trim().to_owned());
+                inputs_en.push(f());
             }
             if label.starts_with("Sample Output") {
-                outputs_en.push(r.inner_html().trim().to_owned());
+                outputs_en.push(f());
             }
         }
 


### PR DESCRIPTION
In these following problems, cargo-atcoder get no input sample and pass local test.

abc001 a
abc001 b
abc001 c
abc001 d
abc002 a
abc002 b
abc002 c
abc002 d
abc003 a
abc003 b
abc003 c
abc003 d
abc004 a
abc004 b
abc004 c
abc004 d
abc005 a
abc005 b
abc005 d
abc006 a
abc006 b
abc006 c
abc006 d
abc019 d
arc001 a
arc001 b
arc001 c
arc001 d
arc002 a
arc002 b
arc002 d
arc003 a
arc003 b
arc003 c
arc003 d
arc004 a
arc004 b
arc004 c
arc004 d
arc005 a
arc005 b
arc005 c
arc005 d
arc006 a
arc006 b
arc006 c
arc006 d
arc007 a
arc007 b
arc007 c
arc007 d
arc008 c
arc008 d
arc009 a
arc009 b
arc009 c
arc009 d
arc010 a
arc010 b
arc010 c
arc010 d
arc011 a
arc011 b
arc011 c
arc011 d
arc012 a
arc012 b
arc012 c
arc012 d
arc013 a
arc013 b
arc013 c
arc013 d
arc014 a
arc014 b
arc014 c
arc014 d
arc015 a
arc015 b
arc015 c
arc015 d
arc016 a
arc016 b
arc016 c
arc016 d
arc017 a
arc017 b
arc017 c
arc017 d
arc018 a
arc018 b
arc018 c
arc018 d
arc019 c
arc019 d
arc020 a
arc020 b
arc026 a
arc026 d
arc070 f
arc078 e

I fixed most of them.
These are the remaining problems that cargo-atcoder get no input sample.

 abc019 d (interactive problem)
 arc001 a (not fixed yet)
 arc001 b (not fixed yet)
 arc001 c (not fixed yet)
 arc001 d (not fixed yet)
 arc070 f (interactive problem)
 arc078 e (interactive problem)