### PR TITLE
Make use of `cargo metadata`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytesize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo_metadata 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -177,7 +178,19 @@ dependencies = [
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml_edit 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1553,6 +1566,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "serde"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,6 +2196,7 @@ dependencies = [
 "checksum bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 "checksum bytesize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "716960a18f978640f25101b5cbf1c6f6b0d3192fab36a2d98ca96f0ecbe41010"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
+"checksum cargo_metadata 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "46e3374c604fb39d1a2f35ed5e4a4e30e60d01fab49446e08f1b3e9a90aef202"
 "checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
@@ -2323,6 +2351,8 @@ dependencies = [
 "checksum security-framework 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8ef2429d7cefe5fd28bd1d2ed41c944547d4ff84776f5935b456da44593a16df"
 "checksum security-framework-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895"
 "checksum selectors 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1b86b100bede4f651059740afc3b6cb83458d7401cb7c1ad96d8a11e91742c86"
+"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
 "checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 "checksum serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 bytesize = "1.0"
+cargo_metadata = "0.9.1"
 chrono = "0.4"
 console = "0.9"
 data-encoding = "2.1"
@@ -32,4 +33,5 @@ tokio = { version = "0.2", features = ["macros", "time"] }
 toml = "0.5"
 toml_edit = "0.1"
 unicode-width = "0.1"
+url = "2.1.1"
 which = "3.1"

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, ensure, Context as _};
+use anyhow::{anyhow, bail, Context as _};
 use cargo_metadata::{Metadata, MetadataCommand, Package, Resolve, Target};
 use std::{env, path::Path, process::Command, str};
 use url::Url;
@@ -42,7 +42,9 @@ impl MetadataExt for Metadata {
             .output()?;
         let stdout = str::from_utf8(&output.stdout)?.trim_end();
         let stderr = str::from_utf8(&output.stderr)?.trim_end();
-        ensure!(output.status.success(), "{}", stderr);
+        if !output.status.success() {
+            bail!("{}", stderr.trim_start_matches("error: "));
+        }
 
         let url = stdout.parse::<Url>()?;
         let fragment = url.fragment().expect("the URL should contain fragment");

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,0 +1,101 @@
+use anyhow::{anyhow, ensure, Context as _};
+use cargo_metadata::{Metadata, MetadataCommand, Package, Resolve, Target};
+use std::{env, path::Path, process::Command, str};
+use url::Url;
+
+pub(crate) fn cargo_metadata(manifest_path: Option<&Path>, cwd: &Path) -> anyhow::Result<Metadata> {
+    // with `--no-deps`, `cargo metadata` does not update the lockfile properly.
+    let mut cmd = MetadataCommand::new();
+    if let Some(manifest_path) = manifest_path {
+        cmd.manifest_path(manifest_path);
+    }
+    cmd.current_dir(cwd).exec().map_err(|err| match err {
+        cargo_metadata::Error::CargoMetadata { stderr } => anyhow!("{}", stderr.trim_end()),
+        err => err.into(),
+    })
+}
+
+pub(crate) trait MetadataExt {
+    fn all_members(&self) -> Vec<&Package>;
+    fn query_for_member<'a>(&'a self, spec: Option<&str>) -> anyhow::Result<&'a Package>;
+    fn find_bin<'a>(&'a self, bin_name: &str) -> anyhow::Result<(&'a Target, &'a Package)>;
+}
+
+impl MetadataExt for Metadata {
+    fn all_members(&self) -> Vec<&Package> {
+        all_members(self).collect()
+    }
+
+    fn query_for_member<'a>(&'a self, spec: Option<&str>) -> anyhow::Result<&'a Package> {
+        let cargo_exe = env::var_os("CARGO").with_context(|| "`$CARGO` should be present")?;
+        let manifest_path = self
+            .resolve
+            .as_ref()
+            .and_then(|Resolve { root, .. }| root.as_ref())
+            .map(|id| self[id].manifest_path.clone())
+            .unwrap_or_else(|| self.workspace_root.join("Cargo.toml"));
+        let output = Command::new(cargo_exe)
+            .arg("pkgid")
+            .arg("--manifest-path")
+            .arg(manifest_path)
+            .args(spec)
+            .output()?;
+        let stdout = str::from_utf8(&output.stdout)?.trim_end();
+        let stderr = str::from_utf8(&output.stderr)?.trim_end();
+        ensure!(output.status.success(), "{}", stderr);
+
+        let url = stdout.parse::<Url>()?;
+        let fragment = url.fragment().expect("the URL should contain fragment");
+        let name = match *fragment.splitn(2, ':').collect::<Vec<_>>() {
+            [name, _] => name,
+            [_] => url
+                .path_segments()
+                .and_then(Iterator::last)
+                .expect("should contain name"),
+            _ => unreachable!(),
+        };
+
+        all_members(self).find(|p| p.name == name).with_context(|| {
+            let spec = spec.expect("should be present here");
+            format!("`{}` is not a member of the workspace", spec)
+        })
+    }
+
+    fn find_bin<'a>(&'a self, bin_name: &str) -> anyhow::Result<(&'a Target, &'a Package)> {
+        all_members(self)
+            .flat_map(|p| all_bins(p).map(move |t| (t, p)))
+            .find(|(Target { name, .. }, _)| name == bin_name)
+            .with_context(|| format!("no bin target named `{}`", bin_name))
+    }
+}
+
+pub(crate) trait PackageExt {
+    fn all_bins(&self) -> Vec<&Target>;
+    fn find_bin<'a>(&'a self, name: &str) -> anyhow::Result<&'a Target>;
+}
+
+impl PackageExt for Package {
+    fn all_bins(&self) -> Vec<&Target> {
+        all_bins(self).collect()
+    }
+
+    fn find_bin<'a>(&'a self, name: &str) -> anyhow::Result<&'a Target> {
+        all_bins(self)
+            .find(|t| t.name == name)
+            .with_context(|| format!("no bin target named `{}`", name))
+    }
+}
+
+fn all_members(metadata: &Metadata) -> impl Iterator<Item = &Package> {
+    metadata
+        .packages
+        .iter()
+        .filter(move |Package { id, .. }| metadata.workspace_members.contains(id))
+}
+
+fn all_bins(package: &Package) -> impl Iterator<Item = &Target> {
+    package
+        .targets
+        .iter()
+        .filter(|Target { kind, .. }| kind.contains(&"bin".to_owned()))
+}


### PR DESCRIPTION
1. To free from CWD.

    Unlike other popular Cargo commands, `cargo-atcoder` currently assumes that CWD equals `$CARGO_MANIFEST_DIR`. We will be able to run `cargo-atcoder` everywhere under the workspace directory.

2. To support `--manifest-path` and `-p|--package`.

    Building dependencies takes long time in general. Even `proconio` takes about 30 seconds with the `derive` feature.

    ```console
    Warming up release build for `abc152`...
       Compiling proc-macro2 v0.4.30
       Compiling unicode-xid v0.1.0
       Compiling syn v0.15.44
       Compiling lazy_static v1.4.0
       Compiling quote v0.6.13
       Compiling proconio-derive v0.1.6
       Compiling proconio v0.3.6
       Compiling abc152 v0.1.0 (/home/ryo/src/local/abc152)
    warning: unused variable: `n`
     --> src/bin/b.rs:5:9
      |
    5 |         n: usize,
      |         ^ help: consider prefixing with an underscore: `_n`
      |
      = note: `#[warn(unused_variables)]` on by default

        Finished release [optimized] target(s) in 41.81s
    ```

    I'd like to propose that we create a large workspace and add the packages to the workspace members. In this way, we can keep using one build cache with the same dependency graph.

    (edit) Then we would have to put `profile.release` on the root manifest, and to rename `bin`s uniquely.

    ```console
    .
    ├── abc157
    │   ├── Cargo.toml
    │   └── src
    ├── abc158
    │   ├── Cargo.toml
    │   └── src
    ├── abc159
    │   ├── Cargo.toml
    │   └── src
    ├── Cargo.lock
    ├── Cargo.toml
    └── target
        ├── debug
        └── release
    ```

    ```toml
    # <workspace-root>/Cargo.toml

    [workspace]
    members = ["abc157", "abc158", "abc159"]
    exclude = ["abc154", "abc155", "abc156"]

    [profile.release]
    lto = true
    panic = 'abort'
    ```

    ```toml
    # <workspace-root>/abc159/Cargo.toml

    [package]
    name = "abc159"
    version = "0.1.0"
    authors = ["Ryo Yamashita <qryxip@gmail.com>"]
    edition = "2018"

    [[bin]]
    name = "abc159-a"
    path = "./src/bin/a.rs"

    [[bin]]
    name = "abc159-b"
    path = "./src/bin/b.rs"

    [[bin]]
    name = "abc159-c"
    path = "./src/bin/c.rs"

    [[bin]]
    name = "abc159-d"
    path = "./src/bin/d.rs"

    [[bin]]
    name = "abc159-e"
    path = "./src/bin/e.rs"

    [[bin]]
    name = "abc159-f"
    path = "./src/bin/f.rs"

    # Not here
    #[profile.release]
    #lto = true
    #panic = 'abort'

    [dependencies]
    proconio = { version = "0.3.6", features = ["derive"] }
    ```

    Currently, `cargo-atcoder` does not work with such a workspace. With `cargo metadata`, we can use `cargo-atcoder` on large workspaces.
