### PR TITLE
Avoid panic while searching for a choice "rust".

### DIFF
--- a/src/atcoder.rs
+++ b/src/atcoder.rs
@@ -537,7 +537,7 @@ impl AtCoder {
                         .trim()
                         .split_whitespace()
                         .next()
-                        .unwrap()
+                        .unwrap_or("")
                         .to_lowercase()
                         .starts_with("rust")
                     {


### PR DESCRIPTION
`cargo-atcoder ` assumes that the format of language choices is like
```
<option value="4005" data-mime="text/x-java">Java (OpenJDK 11.0.6)</option>
<option value="4006" data-mime="text/x-python">Python (3.8.2)</option>
<option value="4007" data-mime="text/x-sh">Bash (5.0.11)</option>
```
However at this time, A `option` element whose text is empty is selected too as language choices.
And the current implementation panics if it tries to parse empty `option`.
This PR avoid that.