### PR TITLE
Fix login panic which happens when `~/.config` doesn't exist

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,7 @@ fn config_path() -> Result<PathBuf> {
     .join("cargo-atcoder.toml");
 
     if !config_path.exists() {
+        fs::create_dir_all(config_path.parent().unwrap())?;
         fs::write(&config_path, DEFAULT_CONFIG_STR)?;
     }
 


### PR DESCRIPTION
In my new environment WSL2, `~/.config` directory doesn't exist.
And `cargo atcoder login` panics with the below message because it assumes that `~/.config` directory already exists.
```
Error: No such file or directory (os error 2)
```
This PR fixes that.