### PR TITLE
Run `cargo install` on the CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,17 +73,32 @@ jobs:
         command: clippy
         args: -- -D warnings
 
+    - name: Run tests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --no-fail-fast --verbose
+
+    # `locked`, `dev-deps`
     - name: Build
       uses: actions-rs/cargo@v1
       with:
         command: build
         args: --verbose
 
-    - name: Run tests
+    # `locked`, `avoid-dev-deps`
+    - name: Install (debug, locked)
       uses: actions-rs/cargo@v1
       with:
-        command: test
-        args: --no-fail-fast --verbose
+        command: install
+        args: --path . --debug --verbose --locked
+
+    # `update`, `avoid-dev-deps`
+    - name: Install (debug)
+      uses: actions-rs/cargo@v1
+      with:
+        command: install
+        args: --path . --debug --verbose
 
   upload:
     strategy:


### PR DESCRIPTION
`cargo install`が壊れる、といったことがたまーに発生するので。