### PR TITLE
Add clone `dev-dependencies`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,7 @@ fn new_project(opt: NewOpt) -> Result<()> {
     let mut manifest = fs::read_to_string(&toml_file)?.parse::<toml_edit::Document>()?;
     let conf_preserved = read_config_preserving()?;
     manifest["dependencies"] = conf_preserved["dependencies"].clone();
+    manifest["dev-dependencies"] = conf_preserved["dev-dependencies"].clone();
     manifest["profile"] = toml_edit::Item::Table({
         let mut tbl = toml_edit::Table::new();
         tbl.set_implicit(true);


### PR DESCRIPTION
はじめまして。いつも使わせていただいて有難うございます。
こちらの変更について考慮していただければ幸いです。

## what I did

configファイルにdev-dependenciesを記述しても生成ファイルに反映されないため、
dev-dependenciesもテンプレートとして追加できるようにした。

## 想定される挙動

`${HOME}/.config/cargo-atcoder.toml`に

```toml
[dev-dependencies]
cli_test_dir = "*"
```

と記述したとき、`cargo atcoder new ...`においてdev-dependenciesもクローンされるようになる。