### PR TITLE
Recommend to set `build.target-dir`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ $ cargo atcoder login
 
 でAtCoderにログインします。httpのセッションを保存します。ユーザー名とパスワードは保存しないので安心して下さい。`clear-session`コマンドでセッション情報を消せます。
 
+## `target`ディレクトリの共有 (任意)
+
+コンテスト用のプロジェクトを作成する前に、次の設定をすることをおすすめします。
+
+プロジェクトを並べる予定のディレクトリで次のコマンドを実行してください。
+
+```console
+$ mkdir ./.cargo
+$ echo '[build]\ntarget-dir = "target"' > ./.cargo/config.toml
+```
+
+これでこのディレクトリに[`build.target-dir`](https://doc.rust-lang.org/cargo/reference/config.html#buildtarget-dir)が設定され、そこから下にあるプロジェクト全体が一つの`target`ディレクトリを共有するようになります。
+そうすることで外部クレートを使う場合、毎回それらのビルドが走ることがなくなります。
+
 ## プロジェクト作成
 
 `new` コマンドでコンテスト用のプロジェクトファイルを作成します。


### PR DESCRIPTION
[cargo-compete](https://github.com/qryxip/cargo-compete/blob/master/README-ja.md)を作る上で、そのようなパッケージの運用を前提にしていますが今のところ問題が無く快適です。`cargo`はもちろん`rust-analyzer`も上手く騙せています。

cargo-competeでは`bin`のリネームを行って被らないようにしていますが、**多分**そうしなくてもさほど問題は無いでしょう。

[`build.target-dir` - Configration - The Cargo Book](https://doc.rust-lang.org/cargo/reference/config.html#buildtarget-dir)
