### PR TITLE
Add deps.rs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Crates.io](https://img.shields.io/crates/v/cargo-atcoder.svg)](https://crates.io/crates/cargo-atcoder)
 ![Workflow Status](https://github.com/tanakh/cargo-atcoder/workflows/Rust/badge.svg)
+[![dependency status](https://deps.rs/repo/github/tanakh/cargo-atcoder/status.svg)](https://deps.rs/repo/github/tanakh/cargo-atcoder)
 [![Join the chat at https://gitter.im/tanakh/cargo-atcoder](https://badges.gitter.im/tanakh/cargo-atcoder.svg)](https://gitter.im/tanakh/cargo-atcoder?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 # cargo-atcoder


### PR DESCRIPTION
[deps.rs](https://deps.rs)は"out of date"や"insecure"なdependencyを警告するbadgeを提供するサービスです。割と長い間"looking for maintainer"だったのですが最近メンテナが決まったのか再開したようです。

[![dependency status](https://deps.rs/repo/github/tanakh/cargo-atcoder/status.svg)](https://deps.rs/repo/github/tanakh/cargo-atcoder)

実際このクレートで使っている`dirs`と`tempdir`がunmaintainedになってrustsecに載っちゃってますが、バッヂを見るだけでこのようなことがわかるようになります。

```console
Crate:  dirs
Title:  dirs is unmaintained, use dirs-next instead
Date:   2020-10-16
URL:    https://rustsec.org/advisories/RUSTSEC-2020-0053
Dependency tree:
dirs 3.0.1
└── cargo-atcoder 0.3.1-alpha.0
```

```console
Crate:  tempdir
Title:  `tempdir` crate has been deprecated; use `tempfile` instead
Date:   2018-02-13
URL:    https://rustsec.org/advisories/RUSTSEC-2018-0017
Dependency tree:
tempdir 0.3.7
└── cargo-atcoder 0.3.1-alpha.0
```
