### PR TITLE
add e option on echo command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ cargo atcoder login
 
 ```console
 $ mkdir ./.cargo
-$ echo '[build]\ntarget-dir = "target"' > ./.cargo/config.toml
+$ echo -e '[build]\ntarget-dir = "target"' > ./.cargo/config.toml
 ```
 
 これでこのディレクトリに[`build.target-dir`](https://doc.rust-lang.org/cargo/reference/config.html#buildtarget-dir)が設定され、そこから下にあるプロジェクト全体が一つの`target`ディレクトリを共有するようになります。


### PR DESCRIPTION
echoコマンド実行時、
-e : エスケープシーケンスを使用する
を付加しました。
デフォルトのechoだと改行の\nが考慮されないようです。

環境
- macOS Catalina
- bash