### PR TITLE
Fix 'conflicts_with' arg, snake_case to kebab-case

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -193,7 +193,7 @@ struct TestOpt {
     #[structopt(long, value_name("PATH"))]
     manifest_path: Option<PathBuf>,
     /// Use custom case from stdin
-    #[structopt(short, long, conflicts_with = "case_num")]
+    #[structopt(short, long, conflicts_with = "case-num")]
     custom: bool,
     /// Submit if test passed
     #[structopt(short, long)]


### PR DESCRIPTION
### structopt::conflicts_withの引数を`case_num`から`case-num`に
`conflicts_with`の引数に指定するオプション名は[デフォルトではkebab-case](https://github.com/TeXitoi/structopt/issues/459#issuecomment-765447573)なので、修正しました。

[main.rs#L187](https://github.com/tanakh/cargo-atcoder/blob/a667d0fee4e9dd5729463aa23a797ba4688563dc/src/main.rs#L187)をコメントアウトした際、修正前ではconflict機能が働かず、`cargo atcoder test`で`--custom`と`case-num`が同時に指定できてしまう。
修正後は指定できないことを確認。
