### PR TITLE
Show compile error if compilation fails

### DIFF
--- a/src/atcoder.rs
+++ b/src/atcoder.rs
@@ -64,6 +64,7 @@ pub struct SubmissionResult {
 pub struct FullSubmissionResult {
     pub result: SubmissionResult,
     pub cases: Vec<CaseResult>,
+    pub compile_error_message: Option<String>,
 }
 
 #[derive(Debug)]
@@ -789,7 +790,19 @@ impl AtCoder {
             }
         }
 
-        let ret = FullSubmissionResult { result, cases };
+        // <h4>コンパイルエラー</h4>
+        // <pre>"error..."</pre>
+        let compile_error_message = (|| -> Option<String> {
+            let sel = Selector::parse("h4+pre").unwrap();
+            let mut it = doc.select(&sel);
+            Some(it.next()?.text().collect::<Vec<&str>>().join(""))
+        })();
+
+        let ret = FullSubmissionResult {
+            result,
+            cases,
+            compile_error_message,
+        };
 
         Ok(ret)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1112,6 +1112,12 @@ fn print_full_result(res: &FullSubmissionResult, verbose: bool) -> Result<()> {
         res.result.memory.as_deref().unwrap_or("N/A")
     );
 
+    if let Some(msg) = res.compile_error_message.as_deref() {
+        println!();
+        println!("Compile Error:");
+        println!("{}", msg);
+    }
+
     if res
         .result
         .status


### PR DESCRIPTION
`TODO.md` に記述されている「コンパイルエラー時はエラーメッセージも取得したい」を解決しました．
コンパイルエラー時は以下のように表示されます．

```sh
Submission detail:

Submission ID: 30210056
Date:          2022-03-18 23:29:18
Problem:       PracticeA - Welcome to AtCoder
Language:      Rust (1.42.0)
Score:         0
Code length:   356 Byte
Result:        Compile Error
Runtime:       N/A
Memory:        N/A

Compile Error:
error[E0277]: `[i32; 3]` is not an iterator
 --> src/main.rs:8:14
  |
8 |     for v in [a, b, c] {
  |              ^^^^^^^^^ borrow the array with `&` or call `.iter()` on it to iterate over it
  |
  = help: the trait `std::iter::Iterator` is not implemented for `[i32; 3]`
  = note: arrays are not iterators, but slices like the following are: `&[1, 2, 3]`
  = note: required by `std::iter::IntoIterator::into_iter`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0277`.
error: could not compile `main`.

To learn more, run the command again with --verbose.
```

しかし，表示はできているものの少し見づらいと感じているので，何か見やすくするためのアイデアをいただきたいです．